### PR TITLE
Avoiding anchor cycle error possible fix

### DIFF
--- a/PvpAlerts/PvpAlerts_3D_System.lua
+++ b/PvpAlerts/PvpAlerts_3D_System.lua
@@ -3327,7 +3327,7 @@ local function SetupNew3DPOIMarker(i, isActivated, isNewObjective)
 		if isActivated then
 			PVP.isWaitingOnTrustedFirstRun = true
 		end
-		local realCameraDistance
+		local _, realCameraDistance
 		realCameraDistance, _, _, coordX, coordY, coordZ = GetCameraInfo()
 		if not realCameraDistance then return end
 		if isActivated or isNewObjective or PVP.currentCameraDistance == 0 then

--- a/PvpAlerts/PvpAlerts_Battleground_Scoreboard.lua
+++ b/PvpAlerts/PvpAlerts_Battleground_Scoreboard.lua
@@ -718,7 +718,7 @@ function ScoreboardList:FilterScrollList()
 			local scores = {}
 			local nTeams = GetBattlegroundNumTeams(battlegroundId)
 			for i = 1, nTeams do
-				table.insert(scores, { GetCurrentBattlegroundScore(i), i })
+				table.insert(scores, { GetCurrentBattlegroundScore(GetCurrentBattlegroundRoundIndex()), i })
 			end
 
 			local function sortingFn(score1, score2)
@@ -958,7 +958,11 @@ function ScoreboardList:SetupPlayerRow(control, data)
 					else
 						medalControl:SetParent(PVP_ScoreboardPlayerMedals)
 					end
-					medalControl:SetAnchor(LEFT, self.lastActiveMedal, RIGHT, 25, 0)
+					if self.lastActiveMedal and self.lastActiveMedal ~= medalControl then
+						medalControl:SetAnchor(LEFT, self.lastActiveMedal, RIGHT, 25, 0)
+					else
+						medalControl:SetAnchor(LEFT, medalControl:GetParent(), LEFT, (numActive - 1) * 25, 0)
+					end
 				end
 				-- control:GetNamedChild('Icon'):SetDesaturation(1)
 				if data.medals[i].medalCount > 1 then

--- a/PvpAlerts/PvpAlerts_Battleground_Scoreboard.lua
+++ b/PvpAlerts/PvpAlerts_Battleground_Scoreboard.lua
@@ -718,7 +718,7 @@ function ScoreboardList:FilterScrollList()
 			local scores = {}
 			local nTeams = GetBattlegroundNumTeams(battlegroundId)
 			for i = 1, nTeams do
-				table.insert(scores, { GetCurrentBattlegroundScore(i), i })
+				table.insert(scores, { GetCurrentBattlegroundScore(GetCurrentBattlegroundRoundIndex(), i), i })
 			end
 
 			local function sortingFn(score1, score2)

--- a/PvpAlerts/PvpAlerts_Battleground_Scoreboard.lua
+++ b/PvpAlerts/PvpAlerts_Battleground_Scoreboard.lua
@@ -718,7 +718,7 @@ function ScoreboardList:FilterScrollList()
 			local scores = {}
 			local nTeams = GetBattlegroundNumTeams(battlegroundId)
 			for i = 1, nTeams do
-				table.insert(scores, { GetCurrentBattlegroundScore(GetCurrentBattlegroundRoundIndex()), i })
+				table.insert(scores, { GetCurrentBattlegroundScore(i), i })
 			end
 
 			local function sortingFn(score1, score2)


### PR DESCRIPTION
The changes I've made:

1. Added a check to ensure we're not anchoring a medal to itself (`self.lastActiveMedal ~= medalControl`)
2. If we can't anchor to the last active medal (either because it's nil or it's the same control), we anchor to the parent instead with an appropriate offset based on the medal's position
3. This maintains the same visual layout but prevents any possibility of circular anchoring

This should resolve the "Avoiding anchor cycle" error while maintaining the intended visual appearance of the medals in the scoreboard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the 3D marker setup to correctly capture camera distance.
  
- **Bug Fixes**
  - Enhanced battleground score retrieval to reflect the current round.
  - Improved medal positioning for a more consistent display in player rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->